### PR TITLE
8329826: GCC 12 reports some compiler error when building jdk8

### DIFF
--- a/hotspot/make/linux/makefiles/adlc.make
+++ b/hotspot/make/linux/makefiles/adlc.make
@@ -66,7 +66,7 @@ CXXFLAGS += -DASSERT
 
 # CFLAGS_WARN holds compiler options to suppress/enable warnings.
 # Compiler warnings are treated as errors
-CFLAGS_WARN = $(WARNINGS_ARE_ERRORS)
+CFLAGS_WARN = $(WARNINGS_ARE_ERRORS) -Wno-register
 CFLAGS += $(CFLAGS_WARN)
 
 OBJECTNAMES = \

--- a/hotspot/make/linux/makefiles/gcc.make
+++ b/hotspot/make/linux/makefiles/gcc.make
@@ -212,7 +212,7 @@ ifeq ($(USE_CLANG), true)
   WARNINGS_ARE_ERRORS += -Wno-return-type -Wno-empty-body
 endif
 
-WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wunused-value -Wformat=2 -Wreturn-type
+WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wunused-value -Wformat=2 -Wreturn-type -Wno-stringop-overflow
 
 ifeq ($(USE_CLANG),)
   # Since GCC 4.3, -Wconversion has changed its meanings to warn these implicit

--- a/hotspot/src/share/vm/gc_implementation/g1/concurrentMark.cpp
+++ b/hotspot/src/share/vm/gc_implementation/g1/concurrentMark.cpp
@@ -2935,13 +2935,23 @@ void ConcurrentMark::print_reachable(const char* str,
     return;
   }
 
-  char file_name[JVM_MAXPATHLEN];
+  // fix gcc 12 build jdk8 fastdebug compiler error:
+  // directive writing up to 4096 bytes into a region of size between 0 and 4096 [-Werror=format-overflow=]
+  // about old code:
+  // char file_name[JVM_MAXPATHLEN];
+  // Leave L 2911~2915 code unchanged, so not affect original logic.
+  char *file_name = (char *) NEW_C_HEAP_ARRAY(char, strlen(G1PrintReachableBaseFile) + 2 + strlen(str), mtGC);
+  if (NULL == file_name) {
+    gclog_or_tty->print_cr("  #### error: NEW_C_HEAP_ARRAY failed.");
+    return;
+  }
   sprintf(file_name, "%s.%s", G1PrintReachableBaseFile, str);
   gclog_or_tty->print_cr("  dumping to file %s", file_name);
 
   fileStream fout(file_name);
   if (!fout.is_open()) {
     gclog_or_tty->print_cr("  #### error: could not open file");
+    FREE_C_HEAP_ARRAY(char, file_name, mtGC);
     return;
   }
 
@@ -2957,6 +2967,7 @@ void ConcurrentMark::print_reachable(const char* str,
 
   gclog_or_tty->print_cr("  done");
   gclog_or_tty->flush();
+  FREE_C_HEAP_ARRAY(char, file_name, mtGC);
 }
 
 #endif // PRODUCT

--- a/hotspot/src/share/vm/opto/type.cpp
+++ b/hotspot/src/share/vm/opto/type.cpp
@@ -2553,9 +2553,12 @@ TypeOopPtr::TypeOopPtr(TYPES t, PTR ptr, ciKlass* k, bool xk, ciObject* o, int o
                    _offset >= InstanceMirrorKlass::offset_of_static_fields()) {
           // Static fields
           assert(o != NULL, "must be constant");
-          ciInstanceKlass* k = o->as_instance()->java_lang_Class_klass()->as_instance_klass();
-          ciField* field = k->get_field_by_offset(_offset, true);
-          assert(field != NULL, "missing field");
+          ciField* field = NULL;
+          if (o != NULL) {
+            ciInstanceKlass* k = o->as_instance()->java_lang_Class_klass()->as_instance_klass();
+            field = k->get_field_by_offset(_offset, true);
+          }
+	  assert(field != NULL, "missing field");
           BasicType basic_elem_type = field->layout_type();
           _is_ptr_to_narrowoop = UseCompressedOops && (basic_elem_type == T_OBJECT ||
                                                        basic_elem_type == T_ARRAY);


### PR DESCRIPTION
Env:
ldd (GNU libc) 2.38
gcc (GCC) 12.3.1 

Test the PR patch;
Build release/fastdebug/slowdebug version pass

Reported issue : https://bugs.openjdk.org/browse/JDK-8329826